### PR TITLE
Upgrade `carrierwave` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'airbrake', '~> 6.2'
 gem 'activerecord-session_store', '~> 1.0'
 
 # file uploading
-gem 'carrierwave', '~> 0.10.0'
+gem 'carrierwave', '~> 1.0'
 
 # misc and system
 gem 'addressable', '~> 2.5.1'
@@ -34,7 +34,7 @@ gem 'elasticsearch-rails', '~> 5.0', '>= 5.0.1'
 
 # cloud interaction
 gem 'aws-sdk-rails', '~> 1.0'
-gem 'fog', '~> 1.38'
+gem 'fog-aws', '~> 2.0'
 
 # google drive and documents (import/export)
 gem 'google-api-client', '~> 0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
   specs:
-    CFPropertyList (2.3.2)
     actionmailer (4.2.7.1)
       actionpack (= 4.2.7.1)
       actionview (= 4.2.7.1)
@@ -106,10 +105,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    carrierwave (0.10.0)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
-      json (>= 1.7)
+    carrierwave (1.2.2)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
       mime-types (>= 1.16)
     ckeditor (4.1.3)
       cocaine
@@ -194,7 +192,7 @@ GEM
     et-orbi (1.0.8)
       tzinfo
     eventmachine (1.0.9.1)
-    excon (0.49.0)
+    excon (0.60.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -208,134 +206,21 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.10)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (1.38.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.1.0)
-      fog-core (~> 1.32)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (<= 0.1.0)
-      fog-json
-      fog-local
-      fog-openstack
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-    fog-aliyun (0.1.0)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (0.9.2)
-      fog-core (~> 1.27)
+    fog-aws (2.0.0)
+      fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.10.1)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto (~> 0.0.2)
-    fog-cloudatcost (0.1.2)
-      fog-core (~> 1.36)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-core (1.40.0)
+    fog-core (1.45.0)
       builder
-      excon (~> 0.49)
+      excon (~> 0.58)
       formatador (~> 0.2)
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
     fog-json (1.0.2)
       fog-core (~> 1.0)
       multi_json (~> 1.10)
-    fog-local (0.3.0)
-      fog-core (~> 1.27)
-    fog-openstack (0.1.6)
-      fog-core (>= 1.39)
-      fog-json (>= 1.0)
-      ipaddress (>= 0.8)
-    fog-powerdns (0.1.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-    fog-profitbricks (0.0.5)
+    fog-xml (0.1.3)
       fog-core
-      fog-xml
-      nokogiri
-    fog-rackspace (0.1.1)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.1)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (0.7.0)
-      fog-core
-      rbvmomi (~> 1.8)
-    fog-xenserver (0.2.3)
-      fog-core
-      fog-xml
-    fog-xml (0.1.2)
-      fog-core
-      nokogiri (~> 1.5, >= 1.5.11)
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-sass (4.4.0)
       sass (>= 3.2)
     foreman (0.78.0)
@@ -393,12 +278,11 @@ GEM
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     hurley (0.2)
-    i18n (0.9.1)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     i18n-js (3.0.2)
       i18n (~> 0.6, >= 0.6.6)
     ice_nine (0.11.2)
-    inflecto (0.0.2)
     ipaddress (0.8.3)
     jbuilder (2.3.1)
       activesupport (>= 3.0.0, < 5)
@@ -442,9 +326,9 @@ GEM
     mime-types (2.99.3)
     mini_magick (4.8.0)
     mini_portile2 (2.3.0)
-    minitest (5.11.1)
+    minitest (5.11.3)
     mono_logger (1.1.0)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nenv (0.3.0)
@@ -569,10 +453,6 @@ GEM
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    rbvmomi (1.8.2)
-      builder
-      nokogiri (>= 1.4.1)
-      trollop
     rdoc (4.2.2)
       json (~> 1.4)
     react-rails (1.6.0)
@@ -705,11 +585,10 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    trollop (2.1.2)
     truncate_html (0.9.3)
     turbolinks (2.5.3)
       coffee-rails
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
     uglifier (3.0.4)
@@ -750,7 +629,6 @@ GEM
     with_advisory_lock (3.1.0)
       activerecord (>= 3.2)
       thread_safe
-    xml-simple (1.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -774,7 +652,7 @@ DEPENDENCIES
   bullet (~> 5.7.3)
   bundler-audit (~> 0.6.0)
   capybara
-  carrierwave (~> 0.10.0)
+  carrierwave (~> 1.0)
   ckeditor
   closure_tree (~> 6.6)
   combine_pdf (~> 1.0.5)
@@ -789,7 +667,7 @@ DEPENDENCIES
   email_spec (~> 2.1)
   factory_girl_rails (~> 4.0)
   faker
-  fog (~> 1.38)
+  fog-aws (~> 2.0)
   font-awesome-sass (~> 4.4.0)
   foreman (~> 0.78.0)
   foundation-rails (~> 6.2.1)

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 CarrierWave.configure do |config|
   if Rails.env.development? && ENV['AWS_ACCESS_KEY_ID'].blank?
     config.storage = :file
   else
-    config.storage = :fog
+    config.fog_provider = 'fog/aws'
     config.fog_credentials = {
       provider: 'AWS',
       aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
@@ -11,6 +13,7 @@ CarrierWave.configure do |config|
     }
     config.fog_directory = ENV['AWS_S3_BUCKET_NAME']
     config.fog_public = true
+    config.storage = :fog
   end
 
   config.cache_dir = "#{Rails.root}/tmp/uploads"


### PR DESCRIPTION
- upgrades `carrierwave` to `1.2.2` according to Snyk.io recommendation
- replaces `fog` gem with more specific `fog-aws` as written in the docs:

> IMPORTANT NOTICE:
> If there's a metagem available for your cloud provider, e.g. `fog-aws`,
> you should be using it instead of requiring the full fog collection to avoid
> unnecessary dependencies.
> 
> 'fog' should be required explicitly only if:
> - The provider you use doesn't yet have a metagem available.
> - You require Ruby 1.9.3 support.


