### PR TITLE
Remove old unused `.htpasswd` template

### DIFF
--- a/.cloud66/htpasswd
+++ b/.cloud66/htpasswd
@@ -1,1 +1,0 @@
-unbounded:$apr1$8vFJYMSO$Y/TBTNQgTE9MX8vPB0r0a1

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,7 +72,5 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.console = true
     Bullet.rails_logger = true
-    Bullet.stacktrace_includes = %w(your_gem your_middleware)
-    Bullet.stacktrace_excludes = %w(their_gem their_middleware)
   end
 end


### PR DESCRIPTION
Also removes redundant lines from `bullet` gem configuration